### PR TITLE
Fix: ProgressCircle accessing properties of null refs

### DIFF
--- a/src/components/common/ProgressCircle.jsx
+++ b/src/components/common/ProgressCircle.jsx
@@ -59,19 +59,28 @@ function ProgressCircle(props) {
 
       const currentPercentage = targetFillPercentage * expansionPercentage;
 
-      progressValueRef.current.innerText = !Number.isNaN(currentPercentage)
-        ? (currentPercentage * 100).toFixed(1)
-        : 0;
+      if (progressValueRef.current) {
+        progressValueRef.current.innerText = !Number.isNaN(currentPercentage)
+          ? (currentPercentage * 100).toFixed(1)
+          : 0;
+      }
     }
 
     function runProgressAnimation() {
-      foregroundCircleRef.current.style.strokeDashoffset = (
-        `${targetDashoffset}px`
-      );
+      if (foregroundCircleRef.current) {
+        foregroundCircleRef.current.style.strokeDashoffset = (
+          `${targetDashoffset}px`
+        );
+      }
 
       const intervalDuration = 25;
 
       const interval = setInterval(() => {
+        if (!foregroundCircleRef.current) {
+          clearInterval(interval);
+          return;
+        }
+
         const currentDashoffset = parseFloat(
           window
             .getComputedStyle(foregroundCircleRef.current)


### PR DESCRIPTION
**Fixes:**
- When returning from the **details page**, if the progress circle was still loading, the script would keep accessing properties of the refs, even after they were set to **_null_** on unmount. This PR fixes that.

![Screenshot of the error fixed by this PR](https://user-images.githubusercontent.com/58959382/99678594-be69e900-2a59-11eb-9703-fca8000cfcdb.png)

